### PR TITLE
Configure the project to be released automatically

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,6 @@
+group 'com.karumi.kotlinsnapshot'
+version '0.0.1'
+
 buildscript {
     ext.kotlin_version = '1.2.10'
 
@@ -9,11 +12,10 @@ buildscript {
     }
 }
 
-group 'com.karumi.kotlinsnapshot'
-version 'unspecified'
-
 apply plugin: 'java'
 apply plugin: 'kotlin'
+apply plugin: 'maven'
+apply plugin: 'signing'
 
 sourceCompatibility = 1.8
 
@@ -66,4 +68,80 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
     args "-F", "src/**/*.kt"
+}
+
+def isReleaseBuild() {
+    return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def getRepositoryUsername() {
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
+signing {
+    required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            // POM signature
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+            // Target repository
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+            }
+
+            pom.groupId = GROUP
+            pom.artifactId = POM_ARTIFACT_ID
+            pom.version = VERSION_NAME
+
+            pom.project {
+                name POM_NAME
+                description POM_DESCRIPTION
+                packaging POM_PACKAGING
+                url POM_URL
+
+                scm {
+                    connection POM_SCM_CONNECTION
+                    developerConnection POM_SCM_DEV_CONNECTION
+                    url POM_SCM_URL
+                }
+
+                licenses {
+                    license {
+                        name POM_LICENCE_NAME
+                        url POM_LICENCE_URL
+                        distribution POM_LICENCE_DIST
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = POM_DEVELOPER_ID
+                        name = POM_DEVELOPER_NAME
+                    }
+                }
+            }
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,18 @@
+POM_NAME=KotlinSnapshot
+POM_ARTIFACT_ID=kotlinsnapshot
+POM_PACKAGING=jar
+
+VERSION_NAME=0.0.1
+VERSION_CODE=000001
+GROUP=com.karumi
+
+POM_DESCRIPTION=Snapshot Testing framework for Kotlin
+POM_URL=https://github.com/Karumi/KotlinSnapshot
+POM_SCM_URL=https://github.com/Karumi/KotlinSnapshot
+POM_SCM_CONNECTION=scm:git@github.com:karumi/KotlinSnapshot.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:karumi/KotlinSnapshot.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=karumi
+POM_DEVELOPER_NAME=Kaurmi


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #1 
* **Related pull-requests:** #18 #20

### :tophat: What is the goal?

Configure the project to be released to Maven Central easily just by executing ``./gradlew uploadArchives``.

### How is it being implemented?

We've added and configured some Gradle plugins needed for this task to the ``build.gradle`` main file. After that, we've configured the ``gradle.properties`` file with all the information needed to release our artifact.

### How can it be tested?

I've uploaded a release and then discarded the artifact just for checking if the configuration works, and it does \o/