### PR TITLE
Replace packageName substring for substringBeforeLast

### DIFF
--- a/core/__snapshot__/InferenceNameTestWithoutPackage_the snap test name will be inferred even the test class doesn't have package.snap
+++ b/core/__snapshot__/InferenceNameTestWithoutPackage_the snap test name will be inferred even the test class doesn't have package.snap
@@ -1,0 +1,1 @@
+Developer(name=Davide, yearsInTheCompany=4)

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
@@ -84,8 +84,7 @@ class Camera(relativePath: String = "") {
         val stackTrace = Thread.currentThread().stackTrace
         val testCaseTrace = stackTrace.toList().firstOrNull { trace ->
             val completeClassName = trace.className.toLowerCase()
-            val packageName = completeClassName
-                .substring(0, completeClassName.lastIndexOf("."))
+            val packageName = completeClassName.substringBeforeLast(".", "")
             val isAJUnitClass = packageName
                 .contains("junit")
             val isAGradleClass = packageName.contains("org.gradle.api.internal.tasks.testing")

--- a/core/src/test/kotlin/InferenceNameTestWithoutPackage.kt
+++ b/core/src/test/kotlin/InferenceNameTestWithoutPackage.kt
@@ -1,0 +1,12 @@
+import com.karumi.kotlinsnapshot.core.Developer
+import com.karumi.kotlinsnapshot.matchWithSnapshot
+import org.junit.Test
+
+class InferenceNameTestWithoutPackage {
+
+    @Test
+    fun `the snap test name will be inferred even the test class doesn't have package`() {
+        val davide = Developer("Davide", 4)
+        davide.matchWithSnapshot()
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** fixes #28 

### :tophat: What is the goal?

* Fix #28 [When the test class doesn't have the package, the test crashes](https://github.com/Karumi/KotlinSnapshot/issues/28)
* Add a test covering the fix.

### How is it being implemented?

The problem was in the method to extract the test method name [Camera#87](https://github.com/Karumi/KotlinSnapshot/blob/master/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt#L87) when it needs to get the package name, and there is a `substring` for removing the class name after a `"."`, then if there isn't a dot, the tests will crash.

I have replaced the `substring` method with a kotlin method calls `substringBeforeLast` which the implementation is: 

```kotlin
public fun String.substringBeforeLast(delimiter: String, missingDelimiterValue: String = this): String {
    val index = lastIndexOf(delimiter)
    return if (index == -1) missingDelimiterValue else substring(0, index)
}
```

Where the first argument it's the delimiter and the second one the default value if there isn't the delimiter.

In this case, I have added as a default value if the dot is missing an empty string because there isn't a package.

### How can it be tested?

There is a new test at the top of the test packages calls `InferenceNameTestWithoutPackage` with the corresponding snapshot file.