### PR TITLE
Remove redundant method

### DIFF
--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/KotlinSnapshot.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/KotlinSnapshot.kt
@@ -7,12 +7,12 @@ class KotlinSnapshot(snapshotsFolder: String = "") {
     private val camera = Camera(snapshotsFolder)
 
     fun matchWithSnapshot(value: Any, snapshotName: String? = null) {
-        camera.matchWithSnapshot(snapshotName, value)
+        camera.matchWithSnapshot(value, snapshotName)
     }
 }
 
 private val camera = Camera()
 
 fun Any.matchWithSnapshot(snapshotName: String? = null) {
-    camera.matchWithSnapshot(snapshotName, this)
+    camera.matchWithSnapshot(this, snapshotName)
 }

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
@@ -14,11 +14,7 @@ class Camera(relativePath: String = "") {
         purgeSnapshotsIfNeeded(snapshotDir)
     }
 
-    fun matchWithSnapshot(value: Any) {
-        matchWithSnapshot(null, value)
-    }
-
-    fun matchWithSnapshot(snapshotName: String? = null, value: Any) {
+    fun matchWithSnapshot(value: Any, snapshotName: String? = null) {
         val snapshotFileName = if (snapshotName != null)
             "$snapshotName.snap"
         else


### PR DESCRIPTION
### :tophat: What is the goal?

* Remove redundant method

### How is it being implemented?

* Remove  `fun matchWithSnapshot(value: Any)` method and use instead `fun matchWithSnapshot(value: Any, snapshotName: String? = null)` with `snapshotName` as optional then you can call to the method using one argument or two arguments 👍 

### How can it be tested?

🤖 ✅ 
