### PR TITLE
Smart text case name extractor

### DIFF
--- a/core/__snapshot__/com.karumi.kotlinsnapshot.core.ValidClassName_the_snap_test_name_will_be_inferred_even_the_test_class_does_not_contains_test_or_spec.snap
+++ b/core/__snapshot__/com.karumi.kotlinsnapshot.core.ValidClassName_the_snap_test_name_will_be_inferred_even_the_test_class_does_not_contains_test_or_spec.snap
@@ -1,0 +1,1 @@
+Developer(name=Fran, yearsInTheCompany=1)

--- a/core/__snapshot__/com.karumi.kotlinsnapshot.core.ValidClassName_the_snap_test_name_will_be_inferred_even_the_test_class_does_not_contains_test_or_spec.snap
+++ b/core/__snapshot__/com.karumi.kotlinsnapshot.core.ValidClassName_the_snap_test_name_will_be_inferred_even_the_test_class_does_not_contains_test_or_spec.snap
@@ -1,1 +1,0 @@
-Developer(name=Fran, yearsInTheCompany=1)

--- a/core/bin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
+++ b/core/bin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
@@ -30,7 +30,9 @@ class InferenceNameSpec {
     }
 }
 
-class InvalidClassName {
+class InferenceNameNotSupported {
+
+    val camera = Camera
 
     @Test(expected = TestNameNotFoundException::class)
     fun if_the_test_name_can_not_be_found_and_exception_will_be_thrown() {

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/KotlinSnapshot.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/KotlinSnapshot.kt
@@ -1,8 +1,9 @@
 package com.karumi.kotlinsnapshot
 
 import com.karumi.kotlinsnapshot.core.Camera
-import com.karumi.kotlinsnapshot.core.SerializationModule
 import com.karumi.kotlinsnapshot.core.KotlinSerialization
+import com.karumi.kotlinsnapshot.core.SerializationModule
+import com.karumi.kotlinsnapshot.core.TestCaseExtractor
 
 class KotlinSnapshot<in A>(
     serializationModule: SerializationModule<A>,
@@ -15,14 +16,18 @@ class KotlinSnapshot<in A>(
         )
     }
 
-    private val camera = Camera(serializationModule, snapshotsFolder)
+    private val camera = Camera(
+        serializationModule,
+        TestCaseExtractor(),
+        snapshotsFolder
+    )
 
     fun matchWithSnapshot(value: A, snapshotName: String? = null) {
         camera.matchWithSnapshot(value, snapshotName)
     }
 }
 
-private val camera = Camera(KotlinSerialization())
+private val camera = Camera(KotlinSerialization(), TestCaseExtractor())
 
 fun Any.matchWithSnapshot(snapshotName: String? = null) {
     camera.matchWithSnapshot(this, snapshotName)

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
@@ -105,5 +105,5 @@ class Camera<in A>(
     }
 
     private fun isTestMethod(method: Method): Boolean =
-        method.annotations.any { TEST_ANNOTATION == it.annotationClass.qualifiedName  }
+        method.annotations.any { TEST_ANNOTATION == it.annotationClass.qualifiedName }
 }

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/TestCaseExtractor.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/TestCaseExtractor.kt
@@ -1,0 +1,26 @@
+package com.karumi.kotlinsnapshot.core
+
+import java.lang.reflect.Method
+
+internal open class TestCaseExtractor {
+
+    companion object {
+        private const val TEST_ANNOTATION = "org.junit.Test"
+    }
+
+    open fun getTestStackElement(): StackTraceElement? {
+        val stackTrace = Thread.currentThread().stackTrace
+        return stackTrace.toList().firstOrNull { trace ->
+            try {
+                val traceClass = Class.forName(trace.className)
+                val method = traceClass.getMethod(trace.methodName)
+                isTestMethod(method)
+            } catch (exception: Exception) {
+                false
+            }
+        }
+    }
+
+    private fun isTestMethod(method: Method): Boolean =
+        method.annotations.any { TEST_ANNOTATION == it.annotationClass.qualifiedName }
+}

--- a/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
+++ b/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
@@ -1,5 +1,6 @@
 package com.karumi.kotlinsnapshot.core
 
+import com.karumi.kotlinsnapshot.exceptions.TestNameNotFoundException
 import com.karumi.kotlinsnapshot.matchWithSnapshot
 import org.junit.Test
 
@@ -29,13 +30,18 @@ class InferenceNameSpec {
     }
 }
 
-class ValidClassName {
+class InferenceNameNotSupported {
 
-    @Test
-    fun the_snap_test_name_will_be_inferred_even_the_test_class_does_not_contains_test_or_spec(
-    ) {
+    private val snap = Camera(KotlinSerialization(), TestCaseExtractorNotSupported())
+
+    @Test(expected = TestNameNotFoundException::class)
+    fun if_the_test_name_can_not_be_found_and_exception_will_be_thrown() {
         val fran = Developer("Fran", 1)
-        fran.matchWithSnapshot()
+        snap.matchWithSnapshot(fran)
+    }
+
+    private class TestCaseExtractorNotSupported : TestCaseExtractor() {
+        override fun getTestStackElement(): StackTraceElement? = null
     }
 }
 

--- a/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
+++ b/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
@@ -1,6 +1,5 @@
 package com.karumi.kotlinsnapshot.core
 
-import com.karumi.kotlinsnapshot.exceptions.TestNameNotFoundException
 import com.karumi.kotlinsnapshot.matchWithSnapshot
 import org.junit.Test
 

--- a/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
+++ b/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
@@ -30,10 +30,11 @@ class InferenceNameSpec {
     }
 }
 
-class InvalidClassName {
+class ValidClassName {
 
-    @Test(expected = TestNameNotFoundException::class)
-    fun if_the_test_name_can_not_be_found_and_exception_will_be_thrown() {
+    @Test
+    fun the_snap_test_name_will_be_inferred_even_the_test_class_does_not_contains_test_or_spec(
+    ) {
         val fran = Developer("Fran", 1)
         fran.matchWithSnapshot()
     }

--- a/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
+++ b/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/InferenceNameTest.kt
@@ -35,7 +35,7 @@ class InferenceNameNotSupported {
     private val snap = Camera(KotlinSerialization(), TestCaseExtractorNotSupported())
 
     @Test(expected = TestNameNotFoundException::class)
-    fun if_the_test_name_can_not_be_found_and_exception_will_be_thrown() {
+    fun if_the_test_name_can_not_be_found_an_exception_will_be_thrown() {
         val fran = Developer("Fran", 1)
         snap.matchWithSnapshot(fran)
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** fixes #33 

### :tophat: What is the goal?

* Any test class name should be valid for inferred the test name.

### How is it being implemented?

* Getting every `Method` for the trace and looking for the annotation `@Test`  (org.junit.Test), this is only valid for JUnit tests.

### How can it be tested?

* You can create a test class with any name without the keywords `test` or `spec` and the tests inside must be inferred automatically.