### PR TITLE
Support window line endings

### DIFF
--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
@@ -54,7 +54,8 @@ internal class Camera(
         diffs.find { diff -> diff.operation != DiffMatchPatch.Operation.EQUAL } != null
 
     private fun matchValueWithExistingSnapshot(snapshotFile: File, value: Any?) {
-        val snapshotContents = snapshotFile.readText()
+        val rawSnapshotContents = snapshotFile.readText()
+        val snapshotContents = replaceWindowsLineEndings(rawSnapshotContents)
         val valueString = serializationModule.serialize(value)
         val diffs = dmp.diffMain(snapshotContents, valueString)
         val hasChanged = differsFromSnapshot(diffs)
@@ -64,6 +65,10 @@ internal class Camera(
             val msg = DiffPrinter.toReadableConsoleMessage(snapshotFile.name, diffs)
             throw SnapshotException(diffs, msg, snapshotContents, valueString)
         }
+    }
+
+    private fun replaceWindowsLineEndings(string: String): String {
+        return string.replace(Regex("\\r\\n"), "\n")
     }
 
     private fun writeSnapshot(update: Boolean, snapshotFile: File, value: Any?) {

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Camera.kt
@@ -67,9 +67,7 @@ internal class Camera(
         }
     }
 
-    private fun replaceWindowsLineEndings(string: String): String {
-        return string.replace(Regex("\\r\\n"), "\n")
-    }
+    private fun replaceWindowsLineEndings(string: String) = string.replace(Regex("\\r\\n"), "\n")
 
     private fun writeSnapshot(update: Boolean, snapshotFile: File, value: Any?) {
         val serializedValue = serializationModule.serialize(value)

--- a/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/CameraTest.kt
+++ b/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/CameraTest.kt
@@ -62,4 +62,12 @@ class CameraTest {
             snapshotException.message!!.matchWithSnapshot()
         }
     }
+
+    @Test
+    fun should_not_throw_snapshot_exception_because_of_Windows_line_endings() {
+        val stringWithWindowsLineEndings = "Line 1\nLine 2\n"
+        stringWithWindowsLineEndings.matchWithSnapshot(
+            "should not throw snapshot exception because of Windows line endings"
+        )
+    }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  None
* **Related pull-requests:** None

### :tophat: What is the goal?

Avoid snapshot failures due to Windows [line endings](https://en.wikipedia.org/wiki/Newline) differing from Unix-like systems .

### :memo: How is it being implemented?

After reading a snapshot, any Windows line ending (\r\n) is replaced by a Unix-like system line ending (\n).

### :boom: How can it be tested?

Added a snapshot test with Windows line endings, shouldn't fail on Unix-like systems.