### PR TITLE
Use more conventional diff colouring

### DIFF
--- a/core/__snapshot__/should print diff to a readable console message.snap
+++ b/core/__snapshot__/should print diff to a readable console message.snap
@@ -1,9 +1,8 @@
-[31mReceived value[0m does not match [32mstored snapshot: "should print diff to a readable console message"[0m
+Received value does not match stored snapshot: "should print diff to a readable console message"
 
-[32m-Snapshot[0m
-[31m+Received[0m
+[38;5;255m {"name":"
+[0m[31m- gabriel
+[0m[32m+ andres
+[0m[38;5;255m ","id":5}
+[0m
 
- {"name":"
-[32m- gabriel
-[0m[31m+ andres
-[0m ","id":5}

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/DiffPrinter.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/DiffPrinter.kt
@@ -8,21 +8,22 @@ internal object DiffPrinter {
 
     private fun printDiff(diff: DiffMatchPatch.Diff): String =
         when (diff.operation) {
-            DiffMatchPatch.Operation.EQUAL, null -> " ${diff.text}\n"
-            DiffMatchPatch.Operation.DELETE -> Term.green("- ${diff.text}\n")
-            DiffMatchPatch.Operation.INSERT -> Term.red("+ ${diff.text}\n")
+            DiffMatchPatch.Operation.EQUAL, null -> Term.white(" ${diff.text}\n")
+            DiffMatchPatch.Operation.DELETE -> Term.red("- ${diff.text}\n")
+            DiffMatchPatch.Operation.INSERT -> Term.green("+ ${diff.text}\n")
         }
 
     fun toReadableConsoleMessage(
         snapshotName: String,
         diffs: LinkedList<DiffMatchPatch.Diff>
     ): String {
-        val sb = StringBuilder("${Term.red("Received value")} does not match ${
-        Term.green("stored snapshot: \"$snapshotName\"")}\n\n${
-        Term.green("-Snapshot")}\n${Term.red("+Received")}\n\n")
+        val sb = StringBuilder(
+            "Received value does not match stored snapshot: \"$snapshotName\"\n\n"
+        )
 
         dmp.diffCleanupSemantic(diffs)
         diffs.forEach { diff -> sb.append(printDiff(diff)) }
+        sb.append("\n\n")
         return sb.toString()
     }
 }

--- a/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Term.kt
+++ b/core/src/main/kotlin/com/karumi/kotlinsnapshot/core/Term.kt
@@ -4,7 +4,9 @@ internal object Term {
     private val RESET = "\u001B[0m"
     private val GREEN = "\u001B[32m"
     private val RED = "\u001B[31m"
+    private val WHITE = "\u001b[38;5;255m"
 
     fun green(s: String): String = "$GREEN$s$RESET"
     fun red(s: String): String = "$RED$s$RESET"
+    fun white(s: String): String = "$WHITE$s$RESET"
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** None
* **Related pull-requests:** None

### :tophat: What is the goal?

Use a more conventional diff colouring in the console message.

### :memo: How is it being implemented?

Deletions are printed in red, additions in green and if a line was not changed, it's printed in white.

### :boom: How can it be tested?

Test which matches the expected message when a SnapshotException has been thrown.

### 👓 Example

When a test fails
![image](https://user-images.githubusercontent.com/9267403/65834608-e38f1b80-e2dc-11e9-819a-13e95ad90898.png)