### PR TITLE
Fix JUnit vintage tests and add vintage engine

### DIFF
--- a/core/__snapshot__/com.karumi.kotlinsnapshot.core.CameraTest_should_throw_snapshot_exception_with_junit_diff_message.snap
+++ b/core/__snapshot__/com.karumi.kotlinsnapshot.core.CameraTest_should_throw_snapshot_exception_with_junit_diff_message.snap
@@ -1,8 +1,7 @@
-[31mReceived value[0m does not match [32mstored snapshot: "should throw snapshot exception when not match.snap"[0m
+Received value does not match stored snapshot: "should throw snapshot exception when not match.snap"
 
-[32m-Snapshot[0m
-[31m+Received[0m
+[38;5;255m will not match
+[0m[31m-  ;)
+[0m
 
- will not match
-[32m-  ;)
-[0m expected:<will not match[ ;)]> but was:<will not match[]>
+ expected:<will not match[ ;)]> but was:<will not match[]>

--- a/core/__snapshot__/should not throw snapshot exception because of Windows line endings.snap
+++ b/core/__snapshot__/should not throw snapshot exception because of Windows line endings.snap
@@ -1,0 +1,2 @@
+Line 1
+Line 2

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,13 +30,14 @@ configurations {
 
 dependencies {
     ktlint "com.github.shyiko:ktlint:0.30.0"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.bitbucket.cowwoc.diff-match-patch:diff-match-patch:1.0"
-    compile "com.google.code.gson:gson:2.8.5"
-    compile  group: 'junit', name: 'junit', version: '4.12'
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation "org.bitbucket.cowwoc.diff-match-patch:diff-match-patch:1.0"
+    implementation "com.google.code.gson:gson:2.8.5"
+    implementation  group: 'junit', name: 'junit', version: '4.12'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.2.0'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.2.0'
+    testRuntime 'org.junit.vintage:junit-vintage-engine:5.2.0'
 }
 
 apply plugin: 'maven'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 24 21:04:41 ECT 2018
+#Tue Oct 01 14:44:39 CEST 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### :pushpin: References
* **Related pull-requests:** #52 #54 

### :tophat: What is the goal?

* Run JUnit 5 and JUnit Vintage (JUnit4) tests
* Fix JUnit4 test didn't update in #54 

### :memo: How is it being implemented?

* Upgrade gradlew version
* Replaced `compile` to `implementation` method 
* Add JUnit Vintage engine which is responsible to run find and run JUnit 4 tests, this error was introduced in the last commit of the PR #52 


### :boom: How can it be tested?

* Now in Travis runs all JUnit tests

**I'd like to improve the Travis output because I can't see the test output easily**