### PR TITLE
Ensure subtypes are also parsed

### DIFF
--- a/core/__snapshot__/com.karumi.kotlinsnapshot.core.ArrayListTest_should serialize any class with a non empty list inside.snap
+++ b/core/__snapshot__/com.karumi.kotlinsnapshot.core.ArrayListTest_should serialize any class with a non empty list inside.snap
@@ -1,0 +1,7 @@
+{
+  "__class__": "TestObject",
+  "list": [
+    "item1",
+    "item2"
+  ]
+}

--- a/core/__snapshot__/com.karumi.kotlinsnapshot.core.ArrayListTest_should serialize any class with an empty list inside.snap
+++ b/core/__snapshot__/com.karumi.kotlinsnapshot.core.ArrayListTest_should serialize any class with an empty list inside.snap
@@ -1,0 +1,4 @@
+{
+  "__class__": "TestObject",
+  "list": []
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.bitbucket.cowwoc.diff-match-patch:diff-match-patch:1.0"
-    implementation "com.google.code.gson:gson:2.8.5"
+    implementation "com.google.code.gson:gson:2.8.6"
     implementation  group: 'junit', name: 'junit', version: '4.12'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.2.0'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.2.0'

--- a/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/ArrayListTest.kt
+++ b/core/src/test/kotlin/com/karumi/kotlinsnapshot/core/ArrayListTest.kt
@@ -1,0 +1,23 @@
+package com.karumi.kotlinsnapshot.core
+
+import com.karumi.kotlinsnapshot.matchWithSnapshot
+import org.junit.Test
+
+class ArrayListTest {
+
+    @Test
+    fun `should serialize any class with an empty list inside`() {
+        val input = TestObject(emptyList())
+
+        input.matchWithSnapshot()
+    }
+
+    @Test
+    fun `should serialize any class with a non empty list inside`() {
+        val input = TestObject(listOf("item1", "item2"))
+
+        input.matchWithSnapshot()
+    }
+
+    data class TestObject(val list: List<String>)
+}


### PR DESCRIPTION
Fixes #68

When declaring a class using a collection supertype the parser wasn't able to find the delegate we should use to parse the implementation detail passed on runtime. The class declared with a generic List wasn't ready to parse ArrayList or LinkedList instances. However, if a class was declared with the specific implementation type it worked like a charm. This PR fixes this issue 😃 
